### PR TITLE
Update deletableResourceGroupPrefixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,6 +30,8 @@ var deletableResourceGroupPrefixes = []string{
 	"azuredisk-csi-driver-",
 	"azurefile-csi-driver-",
 	"blobfuse-csi-driver-",
+	"flannel-",
+	"ctrd-",
 }
 
 type options struct {


### PR DESCRIPTION
Mark resource groups created by jobs for flannel & containerd sig-windows tests as deletable.