### PR TITLE
Add image builder e2e RGs to deletable groups

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,6 +34,8 @@ var deletableResourceGroupPrefixes = []string{
 	"flannel-",
 	"ctrd-",
 	"capz-",
+	"image-builder-e2e-",
+	"pkr-Resource-Group-",
 }
 
 type options struct {


### PR DESCRIPTION
Make sure that packer and image builder e2e resource groups get deleted.